### PR TITLE
Remove unnecessary DisplayVersion from Dell.DisplayManager version 2.2.0.43

### DIFF
--- a/manifests/d/Dell/DisplayManager/2.2.0.43/Dell.DisplayManager.installer.yaml
+++ b/manifests/d/Dell/DisplayManager/2.2.0.43/Dell.DisplayManager.installer.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.6.0.schema.json
 
 PackageIdentifier: Dell.DisplayManager
 PackageVersion: 2.2.0.43
@@ -15,7 +15,6 @@ Dependencies:
 ProductCode: Dell Display Manager 2.2
 AppsAndFeaturesEntries:
 - DisplayName: Dell Display Manager 2.2
-  DisplayVersion: 2.2.0.43
   ProductCode: Dell Display Manager 2.2
 Installers:
 - Architecture: x64
@@ -23,4 +22,4 @@ Installers:
   InstallerSha256: A345EBF111C6215F851DEC71F5790CFF520A2DB8225172EF065031DDCC816BB4
   DisplayInstallWarnings: false
 ManifestType: installer
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/Dell/DisplayManager/2.2.0.43/Dell.DisplayManager.locale.en-US.yaml
+++ b/manifests/d/Dell/DisplayManager/2.2.0.43/Dell.DisplayManager.locale.en-US.yaml
@@ -1,5 +1,5 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.6.0.schema.json
 
 PackageIdentifier: Dell.DisplayManager
 PackageVersion: 2.2.0.43
@@ -15,4 +15,4 @@ LicenseUrl: https://www.dell.com/learn/us/en/uscorp1/terms-of-sale-consumer-lice
 ShortDescription: Dell Display Manager enhances everyday productivity through comprehensive management tools giving you optimal front of screen experience, efficient display management and easy, effortless multitasking.
 InstallationNotes: This package also requires .Net Desktop Runtime 5 (Microsoft.DotNet.DesktopRuntime.5) to work.
 ManifestType: defaultLocale
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0

--- a/manifests/d/Dell/DisplayManager/2.2.0.43/Dell.DisplayManager.yaml
+++ b/manifests/d/Dell/DisplayManager/2.2.0.43/Dell.DisplayManager.yaml
@@ -1,8 +1,8 @@
 # Created with Komac v1.11.0
-# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.5.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.6.0.schema.json
 
 PackageIdentifier: Dell.DisplayManager
 PackageVersion: 2.2.0.43
 DefaultLocale: en-US
 ManifestType: version
-ManifestVersion: 1.5.0
+ManifestVersion: 1.6.0


### PR DESCRIPTION
Issue https://www.github.com/microsoft/winget-pkgs/issues/138520 describes scenarios where DisplayVersion should not be used. This PR removes unnecessary DisplayVersion from the manifest file.